### PR TITLE
Fixed case when only a single digit is being parsed.

### DIFF
--- a/ToolsLibTest/TestNumbers.cpp
+++ b/ToolsLibTest/TestNumbers.cpp
@@ -563,6 +563,38 @@ namespace
 		EXPECT_EQ(1u, ui);
 		EXPECT_EQ(end, &nr[nr.size()]);
 
+		nr = "5";
+		str = &nr[0];
+		end = &nr[nr.size()];
+		scanned = nullptr;
+
+		i = -1;
+		ui = (uint16_t)-1;
+		EXPECT_NO_THROW((i = fromDecimal<int16_t>(str, end, &scanned)));
+		EXPECT_EQ(end, scanned);
+		EXPECT_NO_THROW((ui = fromDecimal<uint16_t>(str, end, &scanned)));
+		EXPECT_EQ(end, scanned);
+
+		EXPECT_EQ(5, i);
+		EXPECT_EQ(5u, ui);
+		EXPECT_EQ(end, &nr[nr.size()]);
+
+		nr = "";
+		str = &nr[0];
+		end = &nr[nr.size()];
+		scanned = nullptr;
+
+		i = -1;
+		ui = (uint16_t)-1;
+		EXPECT_THROW((i = fromDecimal<int16_t>(str, end, &scanned)), invalid_argument);
+		EXPECT_EQ(end, scanned);
+		EXPECT_THROW((ui = fromDecimal<uint16_t>(str, end, &scanned)), invalid_argument);
+		EXPECT_EQ(end, scanned);
+
+		EXPECT_EQ(-1, i);
+		EXPECT_EQ((uint16_t)-1, ui);
+		EXPECT_EQ(end, &nr[nr.size()]);
+
 		nr = "0x";
 		str = &nr[0];
 		end = &nr[nr.size()];

--- a/toolslib/include/toolslib/strings/strton.h
+++ b/toolslib/include/toolslib/strings/strton.h
@@ -133,8 +133,11 @@ namespace toolslib
 
 			if (s >= end)
 			{
-				*endptr = end;
-				_STRTON_ERROR_RETURN(std::string(nptr, end-nptr), EINVAL);
+				if (!ISDIGIT(c) && !ISALPHA(c))
+				{
+					*endptr = end;
+					_STRTON_ERROR_RETURN(std::string(nptr, end - nptr), EINVAL);
+				}
 			}
 
 			if (c == '-')
@@ -262,8 +265,12 @@ namespace toolslib
 
 			if (s >= end)
 			{
-				*endptr = end;
-				_STRTON_ERROR_RETURN(std::string(nptr, end - nptr), EINVAL);
+				// This would trigger if we have only a single digit
+				if (!ISDIGIT(c) && !ISALPHA(c))
+				{
+					*endptr = end;
+					_STRTON_ERROR_RETURN(std::string(nptr, end - nptr), EINVAL);
+				}
 			}
 
 			if (c == '-')


### PR DESCRIPTION
Parsing a number with a single digit caused an exception.
